### PR TITLE
Fix blockquote text contrast in dark mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,6 +18,8 @@
   @apply dark:prose-h3:text-white;
   @apply dark:prose-strong:text-white;
   @apply dark:prose-pre:bg-neutral-900;
+  @apply dark:prose-blockquote:text-neutral-300;
+  @apply dark:prose-blockquote:border-neutral-500;
 }
 
 


### PR DESCRIPTION
Blockquote text was invisible/unreadable in dark mode due to missing
dark mode color overrides. Added text-neutral-300 and border-neutral-500
for blockquotes in dark mode.

https://claude.ai/code/session_01T7fDBY7RdXZ9SNoQiqL1Hq