### PR TITLE
Add Austrian Impressum page (§ 5 ECG, § 25 MedienG)

### DIFF
--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -9,6 +9,7 @@ const currentYear = new Date().getFullYear();
             Designed & Developed with <a href="https://astro.build/">Astro</a>
         </p>
         <p>&copy; {currentYear} Johannes Gnadlinger</p>
+        <p><a href="/impressum">Impressum</a></p>
     </div>
 </footer>
 <style>

--- a/src/components/global/Navigation.astro
+++ b/src/components/global/Navigation.astro
@@ -44,6 +44,14 @@
         <ul
           class="space-y-2 list-none md:space-y-0 md:ml-auto items-center md:inline-flex justify-center text-center md:text-left gap-3"
         >
+          <li>
+            <a
+              href="/impressum"
+              class="text-black dark:text-white hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+            >
+              Impressum
+            </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -1,0 +1,77 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+---
+<BaseLayout>
+  <section class="px-8 md:px-12 mx-auto max-w-3xl py-16 lg:px-32">
+    <h1 class="text-3xl font-bold text-black dark:text-white mb-10">Impressum</h1>
+
+    <!-- § 5 ECG -->
+    <div class="mb-10">
+      <h2 class="text-xl font-semibold text-black dark:text-white mb-4">
+        Angaben gem. § 5 ECG (E-Commerce-Gesetz)
+      </h2>
+      <dl class="space-y-2 text-gray-700 dark:text-gray-300">
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">Betreiber:&nbsp;</dt>
+          <dd class="inline">Johannes Gnadlinger</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">Adresse:&nbsp;</dt>
+          <dd class="inline">[Straße und Hausnummer], [PLZ] [Ort], Österreich</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">E-Mail:&nbsp;</dt>
+          <dd class="inline">[E-Mail-Adresse eintragen]</dd>
+        </div>
+      </dl>
+      <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+        Diese Website wird ausschließlich zu privaten, nicht-kommerziellen Zwecken betrieben.
+        Es besteht keine Umsatzsteuerpflicht.
+      </p>
+    </div>
+
+    <!-- § 25 MedienG -->
+    <div class="mb-10">
+      <h2 class="text-xl font-semibold text-black dark:text-white mb-4">
+        Offenlegung gem. § 25 MedienG (Mediengesetz)
+      </h2>
+      <dl class="space-y-2 text-gray-700 dark:text-gray-300">
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">Medieninhaber:&nbsp;</dt>
+          <dd class="inline">Johannes Gnadlinger</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">Anschrift:&nbsp;</dt>
+          <dd class="inline">[Straße und Hausnummer], [PLZ] [Ort], Österreich</dd>
+        </div>
+        <div>
+          <dt class="font-medium text-black dark:text-white inline">Grundlegende Richtung:&nbsp;</dt>
+          <dd class="inline">
+            Persönlicher Blog zu [Thema eintragen, z.&nbsp;B. Technik, Softwareentwicklung, Reisen].
+            Betrieben als nicht-kommerzielles Privatmedium ohne parteipolitische oder religiöse Ausrichtung.
+          </dd>
+        </div>
+      </dl>
+    </div>
+
+    <!-- Haftungsausschluss -->
+    <div class="mb-10">
+      <h2 class="text-xl font-semibold text-black dark:text-white mb-4">Haftungsausschluss</h2>
+      <p class="text-gray-700 dark:text-gray-300">
+        Trotz sorgfältiger inhaltlicher Kontrolle übernehme ich keine Haftung für die Inhalte
+        externer Links. Für den Inhalt der verlinkten Seiten sind ausschließlich deren Betreiber
+        verantwortlich.
+      </p>
+    </div>
+
+    <!-- Urheberrecht -->
+    <div>
+      <h2 class="text-xl font-semibold text-black dark:text-white mb-4">Urheberrecht</h2>
+      <p class="text-gray-700 dark:text-gray-300">
+        Die auf dieser Website veröffentlichten Inhalte unterliegen dem österreichischen Urheberrecht.
+        Jede Vervielfältigung, Bearbeitung oder Verbreitung außerhalb der Grenzen des Urheberrechts
+        bedarf der schriftlichen Zustimmung des Autors.
+      </p>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -17,11 +17,11 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
         </div>
         <div>
           <dt class="font-medium text-black dark:text-white inline">Adresse:&nbsp;</dt>
-          <dd class="inline">[Straße und Hausnummer], [PLZ] [Ort], Österreich</dd>
+          <dd class="inline">4020 Linz, Österreich</dd>
         </div>
         <div>
           <dt class="font-medium text-black dark:text-white inline">E-Mail:&nbsp;</dt>
-          <dd class="inline">[E-Mail-Adresse eintragen]</dd>
+          <dd class="inline">johannes.gnadlinger1997@gmail.com</dd>
         </div>
       </dl>
       <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
@@ -42,12 +42,12 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
         </div>
         <div>
           <dt class="font-medium text-black dark:text-white inline">Anschrift:&nbsp;</dt>
-          <dd class="inline">[Straße und Hausnummer], [PLZ] [Ort], Österreich</dd>
+          <dd class="inline">4020 Linz, Österreich</dd>
         </div>
         <div>
           <dt class="font-medium text-black dark:text-white inline">Grundlegende Richtung:&nbsp;</dt>
           <dd class="inline">
-            Persönlicher Blog zu [Thema eintragen, z.&nbsp;B. Technik, Softwareentwicklung, Reisen].
+            Persönlicher Blog zu Technik, Alltag und Familie.
             Betrieben als nicht-kommerzielles Privatmedium ohne parteipolitische oder religiöse Ausrichtung.
           </dd>
         </div>


### PR DESCRIPTION
Creates /impressum with legally required sections for a public personal
blog in Austria: provider identification (ECG), media owner declaration
(MedienG), liability disclaimer, and copyright notice. Adds Impressum
link to footer and navigation.

https://claude.ai/code/session_01DVJ1iHwnMmrJsC475TTNFb