### PR TITLE
Fix dark mode inconsistency between list and detail pages

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -29,24 +29,6 @@ const {data} = await sbApi.get(`cdn/stories/blog/${slug}`, {
 
 const story = data.story;
 ---
-<html lang="en">
-<link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="/favicons/favicon.ico"
-/>
-<link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="/favicons/favicon.ico"
-/>
-<head>
-    <meta charset="UTF-8">
-    <title>HelloDad</title>
-</head>
-<body>
 <script>
     import hljs from 'highlight.js';
     import 'highlight.js/styles/github.css'; // Verwende das GitHub-Theme
@@ -119,5 +101,3 @@ const story = data.story;
         background-position: 0 100%
     }
 </style>
-</body>
-</html>


### PR DESCRIPTION
The detail page had its own <html>/<head>/<body> wrapper around <BaseLayout>,
which caused <ThemeScript /> to run inside <body> instead of <head>. This meant
the dark class was never applied before render on the detail page. Removing the
outer HTML wrapper lets BaseLayout provide the full document structure with
ThemeScript in the correct position, matching the pattern used by index.astro.

https://claude.ai/code/session_01JXCvthq1cqoTbKmWuZip6M