### PR TITLE
Fix tag underline color being black in dark mode

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,7 +47,7 @@ const uniqueTags = [
           uniqueTags.map((tag) => (
             <li class="inline-flex items-center uppercase mx-auto font-medium">
               <a href={`/tags/${tag}`} class="max-w-sm leading-tight">
-                <span class="link link-underline dark:link-underline-white text-black dark:text-white pb-2">{tag}</span>
+                <span class="link link-underline text-black dark:text-white pb-2">{tag}</span>
               </a>
             </li>
           ))
@@ -75,7 +75,7 @@ const uniqueTags = [
     background-repeat: no-repeat;
     transition: background-size .5s ease-in-out;
   }
-  .link-underline-white {
+  :global(.dark) .link-underline {
     background-image: linear-gradient(transparent, transparent), linear-gradient(#fff, #fff);
   }
   .link-underline:hover {


### PR DESCRIPTION
The animated underline was always black because dark:link-underline-white
does not work for custom scoped Astro CSS classes. Replace with a
:global(.dark) CSS rule that correctly applies the white underline gradient
when dark mode is active.

https://claude.ai/code/session_01XwqUwKJ7mLy76RbitiYfDi