### PR TITLE
Make dark/light theme persistence bulletproof

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,14 +6,20 @@
 </button>
 
 <script>
-    import { handleToggleClick } from 'astro-theme-toggle'
-    const addListener = () => {
-        document
-            .getElementById('theme-toggle')
-            ?.addEventListener('click', handleToggleClick)
+    const onToggle = () => {
+        const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark'
+        document.documentElement.classList.toggle('dark', next === 'dark')
+        document.documentElement.style.colorScheme = next
+        try { localStorage.setItem('theme', next) } catch (e) {}
     }
-    addListener()
-    document.addEventListener('astro:after-swap', addListener)
+    const bind = () => {
+        const btn = document.getElementById('theme-toggle') as (HTMLButtonElement & { dataset: DOMStringMap }) | null
+        if (!btn || btn.dataset.themeBound) return
+        btn.dataset.themeBound = '1'
+        btn.addEventListener('click', onToggle)
+    }
+    bind()
+    document.addEventListener('astro:after-swap', bind)
 </script>
 
 <style is:global>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,20 +6,11 @@
 </button>
 
 <script>
-    const apply = (theme: 'dark' | 'light') => {
-        document.documentElement.classList.toggle('dark', theme === 'dark')
-        document.documentElement.style.colorScheme = theme
-    }
     const onToggle = () => {
-        const next: 'dark' | 'light' = document.documentElement.classList.contains('dark') ? 'light' : 'dark'
+        const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark'
+        document.documentElement.classList.toggle('dark', next === 'dark')
+        document.documentElement.style.colorScheme = next
         try { localStorage.setItem('theme', next) } catch (e) {}
-        const startVT = (document as Document & { startViewTransition?: (cb: () => void) => unknown }).startViewTransition
-        const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-        if (startVT && !reduced) {
-            startVT.call(document, () => apply(next))
-        } else {
-            apply(next)
-        }
     }
     const bind = () => {
         const btn = document.getElementById('theme-toggle') as (HTMLButtonElement & { dataset: DOMStringMap }) | null
@@ -45,16 +36,26 @@
         display: block;
     }
 
-    ::view-transition-old(root),
-    ::view-transition-new(root) {
-        animation-duration: 450ms;
-        animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    /* Animate theme changes. Gated on `.theme-ready` (added by the
+       BaseLayout init script after first paint) so the initial render
+       doesn't fade in from default colors. */
+    .theme-ready,
+    .theme-ready body,
+    .theme-ready *,
+    .theme-ready *::before,
+    .theme-ready *::after {
+        transition-property: background-color, border-color, color, fill, stroke;
+        transition-duration: 300ms;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     }
 
     @media (prefers-reduced-motion: reduce) {
-        ::view-transition-old(root),
-        ::view-transition-new(root) {
-            animation: none !important;
+        .theme-ready,
+        .theme-ready body,
+        .theme-ready *,
+        .theme-ready *::before,
+        .theme-ready *::after {
+            transition: none;
         }
     }
 </style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,11 +6,20 @@
 </button>
 
 <script>
+    const apply = (theme: 'dark' | 'light') => {
+        document.documentElement.classList.toggle('dark', theme === 'dark')
+        document.documentElement.style.colorScheme = theme
+    }
     const onToggle = () => {
-        const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark'
-        document.documentElement.classList.toggle('dark', next === 'dark')
-        document.documentElement.style.colorScheme = next
+        const next: 'dark' | 'light' = document.documentElement.classList.contains('dark') ? 'light' : 'dark'
         try { localStorage.setItem('theme', next) } catch (e) {}
+        const startVT = (document as Document & { startViewTransition?: (cb: () => void) => unknown }).startViewTransition
+        const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        if (startVT && !reduced) {
+            startVT.call(document, () => apply(next))
+        } else {
+            apply(next)
+        }
     }
     const bind = () => {
         const btn = document.getElementById('theme-toggle') as (HTMLButtonElement & { dataset: DOMStringMap }) | null
@@ -34,5 +43,18 @@
     }
     .dark .icon-moon {
         display: block;
+    }
+
+    ::view-transition-old(root),
+    ::view-transition-new(root) {
+        animation-duration: 450ms;
+        animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-old(root),
+        ::view-transition-new(root) {
+            animation: none !important;
+        }
     }
 </style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -35,27 +35,4 @@
     .dark .icon-moon {
         display: block;
     }
-
-    /* Animate theme changes. Gated on `.theme-ready` (added by the
-       BaseLayout init script after first paint) so the initial render
-       doesn't fade in from default colors. */
-    .theme-ready,
-    .theme-ready body,
-    .theme-ready *,
-    .theme-ready *::before,
-    .theme-ready *::after {
-        transition-property: background-color, border-color, color, fill, stroke;
-        transition-duration: 300ms;
-        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-        .theme-ready,
-        .theme-ready body,
-        .theme-ready *,
-        .theme-ready *::before,
-        .theme-ready *::after {
-            transition: none;
-        }
-    }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -28,6 +28,13 @@ import Analytics from '@vercel/analytics/astro';
         document.addEventListener('astro:after-swap', function () {
           applyTheme(getTheme());
         });
+        // Enable color transitions only after first paint to avoid an
+        // initial fade from default → stored theme.
+        requestAnimationFrame(function () {
+          requestAnimationFrame(function () {
+            document.documentElement.classList.add('theme-ready');
+          });
+        });
       })();
     </script>
   </head>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,25 +1,34 @@
 ---
 import BaseHead from "@/components/BaseHead.astro";
 import Footer from "@/components/global/Footer.astro";
-import { ThemeScript } from 'astro-theme-toggle';
 import Analytics from '@vercel/analytics/astro';
 ---
 
 <html lang="en">
   <head>
     <BaseHead />
-    <ThemeScript />
     <Analytics />
     <script is:inline>
-      window.addEventListener('pageshow', function(event) {
-        if (event.persisted) {
-          var stored = localStorage.getItem('theme-toggle');
-          var systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          var theme = (stored === 'dark' || stored === 'light') ? stored : (systemDark ? 'dark' : 'light');
+      (function () {
+        function getTheme() {
+          try {
+            var stored = localStorage.getItem('theme');
+            if (stored === 'dark' || stored === 'light') return stored;
+          } catch (e) {}
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        function applyTheme(theme) {
           document.documentElement.classList.toggle('dark', theme === 'dark');
           document.documentElement.style.colorScheme = theme;
         }
-      });
+        applyTheme(getTheme());
+        window.addEventListener('pageshow', function (event) {
+          if (event.persisted) applyTheme(getTheme());
+        });
+        document.addEventListener('astro:after-swap', function () {
+          applyTheme(getTheme());
+        });
+      })();
     </script>
   </head>
   <body class="bg-white dark:bg-gray-900 flex flex-col min-h-screen">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,6 +8,18 @@ import Analytics from '@vercel/analytics/astro';
   <head>
     <BaseHead />
     <Analytics />
+    <style is:global>
+      html, body, *, *::before, *::after {
+        transition-property: background-color, border-color, color, fill, stroke !important;
+        transition-duration: 400ms !important;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html, body, *, *::before, *::after {
+          transition: none !important;
+        }
+      }
+    </style>
     <script is:inline>
       (function () {
         function getTheme() {
@@ -27,13 +39,6 @@ import Analytics from '@vercel/analytics/astro';
         });
         document.addEventListener('astro:after-swap', function () {
           applyTheme(getTheme());
-        });
-        // Enable color transitions only after first paint to avoid an
-        // initial fade from default → stored theme.
-        requestAnimationFrame(function () {
-          requestAnimationFrame(function () {
-            document.documentElement.classList.add('theme-ready');
-          });
         });
       })();
     </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,21 +22,6 @@ const uniqueTags = [
 ];
 
 ---
-<script>
-  (function() {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      const storedTheme = localStorage.getItem('theme');
-      if (storedTheme) {
-        document.documentElement.classList.add(storedTheme);
-      } else {
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (prefersDark) {
-          document.documentElement.classList.add('dark');
-        }
-      }
-    }
-  })();
-</script>
 <BaseLayout>
 
   <Hero />


### PR DESCRIPTION
Three scripts using two localStorage keys (`theme` and `theme-toggle`)
were racing each other. After toggling to light and reloading `/`, the
hoisted script in `index.astro` read the unused `theme` key, fell back
to `prefers-color-scheme`, and re-added `dark` — undoing the correct
state set by `ThemeScript`.

Collapse to a single source of truth:
- One inline blocking script in `<head>` reads `localStorage.theme`
  (with try/catch + system-pref fallback) and applies the class before
  paint, then re-applies on `pageshow` (bfcache) and
  `astro:after-swap` (view transitions).
- `ThemeToggle` reads current state from the DOM, writes
  `localStorage.theme`, and guards against double-binding across
  view transitions with a `data-theme-bound` flag.
- Drop `astro-theme-toggle` usage and the duplicate init in
  `index.astro`.