### PR TITLE
feat: RSS Feed, Lesezeit-Schätzung und Verwandte Artikel

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
     skipInline: false,
     drafts: true
   },
-  site: 'https://lexingtonthemes.com',
+  site: 'https://blog.gnadlinger.me',
   integrations: [tailwind(), sitemap(), icon(), storyblok({
     accessToken: env.STORYBLOK_TOKEN,
     components: {

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -22,6 +22,7 @@ Use AstroSeo in all the pages you want different Seo than the index page
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="keywords" content="Blog" />
+<link rel="alternate" type="application/rss+xml" title="HelloDad RSS Feed" href="/rss.xml" />
 <link
   rel="icon"
   type="image/png"

--- a/src/components/entries/EntriesOne.astro
+++ b/src/components/entries/EntriesOne.astro
@@ -1,7 +1,7 @@
 ---
 import { Image } from 'astro:assets';
 
-const { title, url, description, pubDate, image, tags , index} = Astro.props;
+const { title, url, description, pubDate, image, tags, index, readingTime } = Astro.props;
 ---
 
 <li>
@@ -21,8 +21,9 @@ const { title, url, description, pubDate, image, tags , index} = Astro.props;
         <h2 class="mt-2 text-xl font-bold dark:text-white">
           {title}
         </h2>
-        <div class="flex text-xs text-zinc-400 dark:text-white">
-          {pubDate}
+        <div class="flex gap-1 text-xs text-zinc-400 dark:text-white">
+          <span>{pubDate}</span>
+          {readingTime && <span>· {readingTime} min</span>}
         </div>
       </div>
     </div>

--- a/src/components/entries/EntriesOne.astro
+++ b/src/components/entries/EntriesOne.astro
@@ -18,7 +18,7 @@ const { title, url, description, pubDate, image, tags, index, readingTime } = As
       />
       <div class="p-4">
         <p class="text-xs font-semibold text-muted-foreground dark:text-white">{tags}</p>
-        <h2 class="mt-2 text-xl font-bold dark:text-white">
+        <h2 class="mt-2 text-xl font-bold text-black dark:text-white">
           {title}
         </h2>
         <div class="flex gap-1 text-xs text-zinc-400 dark:text-white">

--- a/src/components/global/Footer.astro
+++ b/src/components/global/Footer.astro
@@ -10,6 +10,7 @@ const currentYear = new Date().getFullYear();
         </p>
         <p>&copy; {currentYear} Johannes Gnadlinger</p>
         <p><a href="/impressum">Impressum</a></p>
+        <p><a href="/rss.xml">RSS Feed</a></p>
     </div>
 </footer>
 <style>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,6 +4,9 @@ import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro'
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import {Image} from 'astro:assets';
 import ThemeToggle from "../../components/ThemeToggle.astro";
+import { getReadingTime } from '../../utils/readingTime';
+import { getRelatedPosts } from '../../utils/relatedPosts';
+import RelatedPosts from '../../storyblok/RelatedPosts.astro';
 
 export async function getStaticPaths() {
     const sbApi = useStoryblokApi();
@@ -28,6 +31,26 @@ const {data} = await sbApi.get(`cdn/stories/blog/${slug}`, {
 });
 
 const story = data.story;
+
+const { data: allStoriesData } = await sbApi.get("cdn/stories", {
+    version: import.meta.env.DEV ? "draft" : "published",
+    starts_with: "blog/",
+});
+
+const readingTime = getReadingTime(story.content.content ?? '');
+
+const relatedPosts = getRelatedPosts(
+    story.slug,
+    story.tag_list ?? [],
+    allStoriesData.stories.map((s: any) => ({
+        slug: s.full_slug,
+        tags: s.tag_list ?? [],
+        title: s.content.title,
+        description: s.content.description ?? '',
+        image: s.content.image?.filename ?? '',
+        date: new Date(s.published_at).toLocaleDateString("de-AT", { dateStyle: "medium" }),
+    }))
+);
 ---
 <script>
     import hljs from 'highlight.js';
@@ -57,7 +80,7 @@ const story = data.story;
                 fetchpriority='high'
         />
           <div class="flex  flex-col md:flex-row mt-4 justify-between">
-              <p class="text-xs text-zinc-500 ">{story.content.pubDate?.toString().slice(0, 10)} - Written by: {story.content.author}</p>
+              <p class="text-xs text-zinc-500 ">{story.content.pubDate?.toString().slice(0, 10)} - Written by: {story.content.author} · {readingTime} min Lesezeit</p>
               <div class="flex gap-3">
                   {
                       story.tag_list.map((tag: string) => (
@@ -75,6 +98,7 @@ const story = data.story;
                 <StoryblokComponent blok={story.content}/>
             </div>
         </div>
+        <RelatedPosts posts={relatedPosts} />
         <div class="justify-center pt-4 w-full hidden max-lg:flex">
                 <ThemeToggle />
         </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -40,7 +40,7 @@ const { data: allStoriesData } = await sbApi.get("cdn/stories", {
 const readingTime = getReadingTime(story.content.content ?? '');
 
 const relatedPosts = getRelatedPosts(
-    story.slug,
+    story.full_slug,
     story.tag_list ?? [],
     allStoriesData.stories.map((s: any) => ({
         slug: s.full_slug,

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -84,9 +84,9 @@ const relatedPosts = getRelatedPosts(
               <div class="flex gap-3">
                   {
                       story.tag_list.map((tag: string) => (
-                              <span class="inline-flex items-center uppercase    hover:text-blue-500   text-xs font-medium text-black dark:text-white">
-                    <a href={`/tags/${tag}`}>{tag}</a>
-                  </span>
+                          <a href={`/tags/${tag}`} class="inline-flex items-center uppercase text-xs font-medium text-black dark:text-white hover:text-zinc-500 dark:hover:text-zinc-300 transition-colors">
+                              {tag}
+                          </a>
                       ))
                   }
               </div>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,22 @@
+import rss from '@astrojs/rss';
+import { useStoryblokApi } from '@storyblok/astro';
+
+export async function GET(context: any) {
+  const sbApi = useStoryblokApi();
+  const { data } = await sbApi.get('cdn/stories', {
+    version: 'published',
+    starts_with: 'blog/',
+  });
+
+  return rss({
+    title: 'HelloDad',
+    description: 'Blog von Johannes Gnadlinger',
+    site: context.site,
+    items: data.stories.map((story: any) => ({
+      title: story.content.title,
+      pubDate: new Date(story.published_at),
+      description: story.content.description ?? '',
+      link: `/blog/${story.slug}`,
+    })),
+  });
+}

--- a/src/pages/tags/blog/[...slug].astro
+++ b/src/pages/tags/blog/[...slug].astro
@@ -40,7 +40,7 @@ const { data: allStoriesData } = await sbApi.get("cdn/stories", {
 const readingTime = getReadingTime(story.content.content ?? '');
 
 const relatedPosts = getRelatedPosts(
-    story.slug,
+    story.full_slug,
     story.tag_list ?? [],
     allStoriesData.stories.map((s: any) => ({
         slug: s.full_slug,

--- a/src/pages/tags/blog/[...slug].astro
+++ b/src/pages/tags/blog/[...slug].astro
@@ -83,9 +83,9 @@ const relatedPosts = getRelatedPosts(
               <div class="flex gap-3">
                   {
                       story.tag_list.map((tag: string) => (
-                              <span class="inline-flex items-center uppercase    hover:text-blue-500   text-xs font-medium text-black dark:text-white">
-                    <a href={`/tags/${tag}`}>{tag}</a>
-                  </span>
+                          <a href={`/tags/${tag}`} class="inline-flex items-center uppercase text-xs font-medium text-black dark:text-white hover:text-zinc-500 dark:hover:text-zinc-300 transition-colors">
+                              {tag}
+                          </a>
                       ))
                   }
               </div>

--- a/src/pages/tags/blog/[...slug].astro
+++ b/src/pages/tags/blog/[...slug].astro
@@ -4,6 +4,9 @@ import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro'
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import {Image} from 'astro:assets';
 import ThemeToggle from "../../../components/ThemeToggle.astro";
+import { getReadingTime } from '../../../utils/readingTime';
+import { getRelatedPosts } from '../../../utils/relatedPosts';
+import RelatedPosts from '../../../storyblok/RelatedPosts.astro';
 
 export async function getStaticPaths() {
     const sbApi = useStoryblokApi();
@@ -28,6 +31,26 @@ const {data} = await sbApi.get(`cdn/stories/blog/${slug}`, {
 });
 
 const story = data.story;
+
+const { data: allStoriesData } = await sbApi.get("cdn/stories", {
+    version: import.meta.env.DEV ? "draft" : "published",
+    starts_with: "blog/",
+});
+
+const readingTime = getReadingTime(story.content.content ?? '');
+
+const relatedPosts = getRelatedPosts(
+    story.slug,
+    story.tag_list ?? [],
+    allStoriesData.stories.map((s: any) => ({
+        slug: s.full_slug,
+        tags: s.tag_list ?? [],
+        title: s.content.title,
+        description: s.content.description ?? '',
+        image: s.content.image?.filename ?? '',
+        date: new Date(s.published_at).toLocaleDateString("de-AT", { dateStyle: "medium" }),
+    }))
+);
 ---
 <script>
     import hljs from 'highlight.js';
@@ -56,7 +79,7 @@ const story = data.story;
                 loading="eager"
         />
           <div class="flex  flex-col md:flex-row mt-4 justify-between">
-              <p class="text-xs text-zinc-500 ">{story.content.pubDate?.toString().slice(0, 10)} - Written by: {story.content.author}</p>
+              <p class="text-xs text-zinc-500 ">{story.content.pubDate?.toString().slice(0, 10)} - Written by: {story.content.author} · {readingTime} min Lesezeit</p>
               <div class="flex gap-3">
                   {
                       story.tag_list.map((tag: string) => (
@@ -74,6 +97,7 @@ const story = data.story;
                 <StoryblokComponent blok={story.content}/>
             </div>
         </div>
+        <RelatedPosts posts={relatedPosts} />
         <div class="justify-center pt-4 w-full hidden max-lg:flex">
                 <ThemeToggle />
         </div>

--- a/src/storyblok/BlogPostList.astro
+++ b/src/storyblok/BlogPostList.astro
@@ -1,6 +1,7 @@
 ---
 import { storyblokEditable } from '@storyblok/astro'
 import EntriesOne from "../components/entries/EntriesOne.astro";
+import { getReadingTime } from '../utils/readingTime';
 
 const {blokdata} = Astro.props;
 
@@ -12,6 +13,7 @@ const posts = blokdata.stories.map(story => {
         image: story.content.image,
         tags: story.tag_list ? story.tag_list : "",
         slug: story.full_slug,
+        readingTime: getReadingTime(story.content.content ?? story.content.description ?? ''),
     }
 })
 
@@ -28,6 +30,7 @@ const { blok } = Astro.props
                     image={post.image?.filename}
                     tags={post.tags}
                     index={index}
+                    readingTime={post.readingTime}
             />
     )))}
 </ul>

--- a/src/storyblok/RelatedPosts.astro
+++ b/src/storyblok/RelatedPosts.astro
@@ -25,7 +25,7 @@ const { posts } = Astro.props as { posts: PostSummary[] };
             )}
             <div class="p-3">
               <p class="text-xs text-zinc-400 dark:text-zinc-500 mb-1">{post.date}</p>
-              <h3 class="text-sm font-medium text-black dark:text-white group-hover:text-blue-500 transition-colors line-clamp-2">
+              <h3 class="text-sm font-medium text-black dark:text-white line-clamp-2">
                 {post.title}
               </h3>
             </div>

--- a/src/storyblok/RelatedPosts.astro
+++ b/src/storyblok/RelatedPosts.astro
@@ -1,0 +1,37 @@
+---
+import { Image } from 'astro:assets';
+import type { PostSummary } from '../utils/relatedPosts';
+
+const { posts } = Astro.props as { posts: PostSummary[] };
+---
+
+{posts.length > 0 && (
+  <section class="mt-16 max-w-2xl mx-auto border-t pt-10 dark:border-slate-700">
+    <h2 class="text-sm font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mb-6">Verwandte Artikel</h2>
+    <ul class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      {posts.map(post => (
+        <li>
+          <a href={`/${post.slug}`} class="group block rounded-lg border dark:border-slate-600 overflow-hidden hover:shadow-md transition-shadow">
+            {post.image && (
+              <Image
+                src={`${post.image}/m/600x400/filters:format(webp)`}
+                alt={post.title}
+                width={300}
+                height={200}
+                class="w-full h-auto"
+                style="aspect-ratio: 3/2; object-fit: cover;"
+                loading="lazy"
+              />
+            )}
+            <div class="p-3">
+              <p class="text-xs text-zinc-400 dark:text-zinc-500 mb-1">{post.date}</p>
+              <h3 class="text-sm font-medium text-black dark:text-white group-hover:text-blue-500 transition-colors line-clamp-2">
+                {post.title}
+              </h3>
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  </section>
+)}

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -1,0 +1,19 @@
+function extractTextFromNode(node: any): string {
+  if (!node) return '';
+  if (node.text) return node.text;
+  if (Array.isArray(node.content)) return node.content.map(extractTextFromNode).join(' ');
+  return '';
+}
+
+export function getReadingTime(content: string | object): number {
+  let text: string;
+  if (typeof content === 'object' && content !== null) {
+    text = extractTextFromNode(content);
+  } else if (typeof content === 'string' && content.includes('<')) {
+    text = content.replace(/<[^>]*>/g, ' ');
+  } else {
+    text = content as string;
+  }
+  const words = text.trim().split(/\s+/).filter(w => w.length > 0).length;
+  return Math.max(1, Math.ceil(words / 200));
+}

--- a/src/utils/relatedPosts.ts
+++ b/src/utils/relatedPosts.ts
@@ -1,0 +1,24 @@
+export interface PostSummary {
+  slug: string;
+  tags: string[];
+  title: string;
+  description: string;
+  image: string;
+  date: string;
+}
+
+export function getRelatedPosts(
+  currentSlug: string,
+  currentTags: string[],
+  allPosts: PostSummary[],
+  limit = 3
+): PostSummary[] {
+  return allPosts
+    .filter(p => p.slug !== currentSlug && p.tags.some(t => currentTags.includes(t)))
+    .sort((a, b) => {
+      const aShared = a.tags.filter(t => currentTags.includes(t)).length;
+      const bShared = b.tags.filter(t => currentTags.includes(t)).length;
+      return bShared - aShared;
+    })
+    .slice(0, limit);
+}


### PR DESCRIPTION
- RSS Feed: src/pages/rss.xml.ts aktiviert (@astrojs/rss war bereits installiert), <link rel="alternate"> in BaseHead, Link im Footer; site-URL korrigiert auf blog.gnadlinger.me
- Lesezeit: src/utils/readingTime.ts (getReadingTime), Anzeige in EntriesOne-Karten und im Blog-Post-Header (·N min Lesezeit)
- Verwandte Artikel: src/utils/relatedPosts.ts (getRelatedPosts tag-basiert), src/storyblok/RelatedPosts.astro-Komponente, Einbindung am Ende jeder Post-Seite

https://claude.ai/code/session_01LKsvRXf7pnVytbdjp8wB26