### PR TITLE
fix: dynamic SEO/meta tags per page – replace static placeholders

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,55 +1,97 @@
 ---
 import "../styles/global.css";
-import { AstroSeo } from "@astrolib/seo";
+import {
+  SITE_TITLE,
+  SITE_DESCRIPTION,
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_OG_IMAGE,
+} from "../consts";
+
+interface Props {
+  /** Page-specific title. Rendered as "{title} · HelloDad". Omit for homepage. */
+  title?: string;
+  /** Page description for <meta name="description"> and og:description. */
+  description?: string;
+  /** Absolute URL or Storyblok CDN path for og:image / twitter:image. */
+  image?: string;
+  /** Canonical URL. Defaults to the current page URL derived from Astro.url. */
+  url?: string;
+  /** og:type – "article" for blog posts, "website" everywhere else. */
+  type?: "website" | "article";
+  /** ISO-8601 date string for article:published_time (article type only). */
+  publishedDate?: string;
+}
+
+const {
+  title,
+  description = SITE_DESCRIPTION,
+  image,
+  type = "website",
+  publishedDate,
+} = Astro.props;
+
+const pageTitle = title ? `${title} · ${SITE_TITLE}` : SITE_TITLE;
+
+// Use the explicitly passed URL, or derive it from the current page path so
+// every page gets a unique, correct canonical without any hardcoding.
+const canonicalURL =
+  Astro.props.url ?? new URL(Astro.url.pathname, SITE_URL).href;
+
+// Ensure the OG image is always an absolute URL.
+const rawImage = image ?? DEFAULT_OG_IMAGE;
+const ogImage = rawImage.startsWith("http")
+  ? rawImage
+  : `${SITE_URL}${rawImage}`;
 ---
-<!---
-Use AstroSeo in all the pages you want different Seo than the index page
--->
-<AstroSeo
-  title="HelloDad"
-  description="Your site description goes here"
-  canonical="https://blog.gnadlinger.me"
-  openGraph={{
-    url: "https://blog.gnadlinger.me",
-    title: "HelloDad",
-    description: "Blog von Johannes Gnadlinger",
-    site_name: "YourSitesName",
-  }}
-/>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
 <meta charset="UTF-8" />
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+
+<title>{pageTitle}</title>
+<meta name="description" content={description} />
+<link rel="canonical" href={canonicalURL} />
+
+<!-- Open Graph -->
+<meta property="og:type" content={type} />
+<meta property="og:url" content={canonicalURL} />
+<meta property="og:site_name" content={SITE_NAME} />
+<meta property="og:title" content={pageTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={ogImage} />
+{type === "article" && publishedDate && (
+  <meta property="article:published_time" content={publishedDate} />
+)}
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={pageTitle} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImage} />
+
+<!-- Misc -->
 <meta name="keywords" content="Blog" />
-<link rel="alternate" type="application/rss+xml" title="HelloDad RSS Feed" href="/rss.xml" />
 <link
-  rel="icon"
-  type="image/png"
-  sizes="32x32"
-  href="/favicons/favicon.ico"
+  rel="alternate"
+  type="application/rss+xml"
+  title="HelloDad RSS Feed"
+  href="/rss.xml"
 />
-<link
-  rel="icon"
-  type="image/png"
-  sizes="16x16"
-  href="/favicons/favicon.ico"
-/>
+<link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon.ico" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon.ico" />
 <meta name="msapplication-TileColor" content="#ffffff" />
 <meta name="theme-color" content="#ffffff" />
-<!-- HTML in your document's head -->
-
 <link
-        href="https://api.fontshare.com/v2/css?f[]=jet-brains-mono@1,2&display=swap"
-        rel="stylesheet"
-        type="text/css"
-        media="print"
-        onload="this.media='all'"
+  href="https://api.fontshare.com/v2/css?f[]=jet-brains-mono@1,2&display=swap"
+  rel="stylesheet"
+  type="text/css"
+  media="print"
+  onload="this.media='all'"
 />
 <link
-        href="https://fonts.googleapis.com/css2?family=Gilda+Display&display=swap"
-        rel="stylesheet"
-        type="text/css"
-        media="print"
-        onload="this.media='all'"
+  href="https://fonts.googleapis.com/css2?family=Gilda+Display&display=swap"
+  rel="stylesheet"
+  type="text/css"
+  media="print"
+  onload="this.media='all'"
 />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,7 @@
+export const SITE_TITLE = "HelloDad";
+export const SITE_DESCRIPTION =
+  "Blog von Johannes Gnadlinger – Familie, Essen und Tech aus Linz";
+export const SITE_URL = "https://blog.gnadlinger.me";
+export const SITE_NAME = "HelloDad";
+// Place a 1200×630 image at /public/og-default.jpg for the fallback OG image.
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/og-default.jpg`;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,11 +2,29 @@
 import BaseHead from "@/components/BaseHead.astro";
 import Footer from "@/components/global/Footer.astro";
 import Analytics from '@vercel/analytics/astro';
+
+interface Props {
+  title?: string;
+  description?: string;
+  image?: string;
+  url?: string;
+  type?: "website" | "article";
+  publishedDate?: string;
+}
+
+const { title, description, image, url, type, publishedDate } = Astro.props;
 ---
 
 <html lang="en">
   <head>
-    <BaseHead />
+    <BaseHead
+      title={title}
+      description={description}
+      image={image}
+      url={url}
+      type={type}
+      publishedDate={publishedDate}
+    />
     <Analytics />
     <style is:global>
       html, body, *, *::before, *::after {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,6 +2,7 @@
 import {useStoryblokApi} from '@storyblok/astro'
 import StoryblokComponent from '@storyblok/astro/StoryblokComponent.astro'
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { SITE_URL } from "../../consts";
 import {Image} from 'astro:assets';
 import ThemeToggle from "../../components/ThemeToggle.astro";
 import { getReadingTime } from '../../utils/readingTime';
@@ -62,7 +63,14 @@ const relatedPosts = getRelatedPosts(
     });
 </script>
 
-<BaseLayout>
+<BaseLayout
+  title={story.content.title}
+  description={story.content.description || undefined}
+  image={`${story.content.image.filename}/m/1200x630/filters:format(webp)`}
+  url={new URL(`/blog/${slug}`, SITE_URL).href}
+  type="article"
+  publishedDate={story.content.pubDate}
+>
     <div class="relative w-full invisible lg:visible">
         <div class="absolute right-5 top-5 lg:right-10 lg:top-10">
             <ThemeToggle />

--- a/src/pages/impressum.astro
+++ b/src/pages/impressum.astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
 ---
-<BaseLayout>
+<BaseLayout title="Impressum">
   <section class="px-8 md:px-12 mx-auto max-w-3xl py-16 lg:px-32">
     <h1 class="text-3xl font-bold text-black dark:text-white mb-10">Impressum</h1>
 

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -29,7 +29,7 @@ let filteredStories = data.stories.filter(story => story.tag_list.includes(tag))
 data.stories = filteredStories;
 ---
 
-<BaseLayout pageTitle={tag}>
+<BaseLayout title={`Blogposts „${tag}"`}>
   <div class="relative w-full">
     <div class="absolute right-5 top-5 lg:right-10 lg:top-10">
       <ThemeToggle />

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -12,7 +12,7 @@ const uniqueTags = [
 ];
 ---
 
-<BaseLayout pageTitle="Tags">
+<BaseLayout title="Alle Tags">
   <Hero />
   <section>
     <ol role="list" class="flex flex-wrap gap-3">


### PR DESCRIPTION
- Add src/consts.ts with SITE_TITLE, SITE_DESCRIPTION, SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE
- Rewrite BaseHead.astro: accepts title/description/image/url/type/publishedDate props,
  generates <title>, canonical, og:*, twitter:card tags dynamically; canonical URL
  derived from Astro.url.pathname + SITE_URL so every page gets a unique correct value
- Update BaseLayout.astro to accept and forward SEO props to BaseHead
- Wire blog/[...slug].astro: passes post title, description, Storyblok OG image
  (1200×630), canonical /blog/{slug} URL, type="article", and publishedDate
- Fix tags/[tag].astro: replace unused pageTitle prop with real title prop
- Fix tags/index.astro and impressum.astro: add descriptive title props
- Remove duplicate charset/viewport tags and static AstroSeo placeholder values

https://claude.ai/code/session_01369uKKQXpympF8UhHNc9a7