### PR TITLE
fix: auto-generate unique post description when CMS description is empty

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,7 +5,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { SITE_URL } from "../../consts";
 import {Image} from 'astro:assets';
 import ThemeToggle from "../../components/ThemeToggle.astro";
-import { getReadingTime } from '../../utils/readingTime';
+import { getReadingTime, getExcerpt } from '../../utils/readingTime';
 import { getRelatedPosts } from '../../utils/relatedPosts';
 import { getAllStories, contentVersion } from '../../utils/storyblok';
 import RelatedPosts from '../../storyblok/RelatedPosts.astro';
@@ -66,7 +66,7 @@ const heroImage = story.content.image?.filename;
 
 <BaseLayout
   title={story.content.title}
-  description={story.content.description || undefined}
+  description={story.content.description || getExcerpt(story.content.content) || undefined}
   image={heroImage ? `${heroImage}/m/1200x630/filters:format(webp)` : undefined}
   url={new URL(`/blog/${slug}`, SITE_URL).href}
   type="article"

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -5,15 +5,30 @@ function extractTextFromNode(node: any): string {
   return '';
 }
 
-export function getReadingTime(content: string | object): number {
-  let text: string;
+function toPlainText(content: string | object): string {
   if (typeof content === 'object' && content !== null) {
-    text = extractTextFromNode(content);
-  } else if (typeof content === 'string' && content.includes('<')) {
-    text = content.replace(/<[^>]*>/g, ' ');
-  } else {
-    text = content as string;
+    return extractTextFromNode(content);
   }
+  if (typeof content === 'string' && content.includes('<')) {
+    return content.replace(/<[^>]*>/g, ' ');
+  }
+  return (content as string) ?? '';
+}
+
+export function getReadingTime(content: string | object): number {
+  const text = toPlainText(content);
   const words = text.trim().split(/\s+/).filter(w => w.length > 0).length;
   return Math.max(1, Math.ceil(words / 200));
+}
+
+/**
+ * Derives a unique meta-description excerpt from a post's actual body
+ * content, used as a fallback when the CMS `description` field is empty.
+ */
+export function getExcerpt(content: string | object, maxLength = 160): string {
+  const text = toPlainText(content).trim().replace(/\s+/g, ' ');
+  if (text.length <= maxLength) return text;
+  const truncated = text.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength)}…`;
 }


### PR DESCRIPTION
og:site_name already correctly resolves to "HelloDad" and the old static
placeholder strings were removed in a prior commit. The remaining gap was
that posts without a manually set Storyblok description all fell back to
the same generic site-wide description. Add getExcerpt() (reusing the
existing richtext text-extraction logic from getReadingTime) to derive a
unique excerpt from each post's actual content as the fallback instead.

https://claude.ai/code/session_01LaRRnuhf3kqetdh86UzQqz