### PR TITLE
Add font size toggle for accessibility

### DIFF
--- a/src/components/FontSizeToggle.astro
+++ b/src/components/FontSizeToggle.astro
@@ -1,0 +1,71 @@
+<button id="font-size-toggle" aria-label="Schriftgröße ändern">
+    <span class="fs-icon fs-icon-normal" aria-hidden="true">A</span>
+    <span class="fs-icon fs-icon-large" aria-hidden="true">A</span>
+    <span class="fs-icon fs-icon-xl" aria-hidden="true">A</span>
+</button>
+
+<script>
+    const SIZES = ['normal', 'large', 'xl'] as const;
+    type FontSize = typeof SIZES[number];
+
+    const getSize = (): FontSize => {
+        const attr = document.documentElement.getAttribute('data-font-size');
+        return (SIZES.includes(attr as FontSize) ? attr : 'normal') as FontSize;
+    };
+
+    const applySize = (size: FontSize) => {
+        if (size === 'normal') document.documentElement.removeAttribute('data-font-size');
+        else document.documentElement.setAttribute('data-font-size', size);
+        try { localStorage.setItem('font-size', size); } catch (e) {}
+    };
+
+    const onToggle = () => {
+        const current = getSize();
+        const next = SIZES[(SIZES.indexOf(current) + 1) % SIZES.length];
+        applySize(next);
+    };
+
+    const bind = () => {
+        const btn = document.getElementById('font-size-toggle') as (HTMLButtonElement & { dataset: DOMStringMap }) | null;
+        if (!btn || btn.dataset.fsBound) return;
+        btn.dataset.fsBound = '1';
+        btn.addEventListener('click', onToggle);
+    };
+    bind();
+    document.addEventListener('astro:after-swap', bind);
+</script>
+
+<style is:global>
+    #font-size-toggle {
+        display: flex;
+        align-items: baseline;
+        gap: 1px;
+        cursor: pointer;
+        color: inherit;
+        background: none;
+        border: none;
+        padding: 0;
+        line-height: 1;
+    }
+
+    .fs-icon {
+        font-weight: 600;
+        font-family: sans-serif;
+        line-height: 1;
+    }
+
+    /* Normal state: show only the medium A */
+    .fs-icon-normal { display: none; font-size: 0.85rem; }
+    .fs-icon-large  { display: block; font-size: 1.1rem; }
+    .fs-icon-xl     { display: none; font-size: 1.4rem; }
+
+    /* Large state */
+    html[data-font-size="large"] .fs-icon-normal { display: none; }
+    html[data-font-size="large"] .fs-icon-large  { display: none; }
+    html[data-font-size="large"] .fs-icon-xl     { display: block; }
+
+    /* XL state: cycle back indicator – show small A */
+    html[data-font-size="xl"] .fs-icon-normal { display: block; }
+    html[data-font-size="xl"] .fs-icon-large  { display: none; }
+    html[data-font-size="xl"] .fs-icon-xl     { display: none; }
+</style>

--- a/src/components/landing/Hero.astro
+++ b/src/components/landing/Hero.astro
@@ -1,8 +1,10 @@
 ---
 import ThemeToggle from "../ThemeToggle.astro";
+import FontSizeToggle from "../FontSizeToggle.astro";
 ---
 <div class="relative w-full">
-  <div class="absolute right-5 top-5 lg:right-10 lg:top-10">
+  <div class="absolute right-5 top-5 lg:right-10 lg:top-10 flex items-center gap-3">
+    <FontSizeToggle />
     <ThemeToggle />
   </div>
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -65,12 +65,28 @@ const { title, description, image, url, type, publishedDate } = Astro.props;
           var meta = document.querySelector('meta[name="theme-color"]');
           if (meta) meta.setAttribute('content', theme === 'dark' ? '#111827' : '#ffffff');
         }
+        function getFontSize() {
+          try {
+            var s = localStorage.getItem('font-size');
+            if (s === 'large' || s === 'xl') return s;
+          } catch (e) {}
+          return 'normal';
+        }
+        function applyFontSize(size) {
+          if (size === 'normal') document.documentElement.removeAttribute('data-font-size');
+          else document.documentElement.setAttribute('data-font-size', size);
+        }
         applyTheme(getTheme());
+        applyFontSize(getFontSize());
         window.addEventListener('pageshow', function (event) {
-          if (event.persisted) applyTheme(getTheme());
+          if (event.persisted) {
+            applyTheme(getTheme());
+            applyFontSize(getFontSize());
+          }
         });
         document.addEventListener('astro:after-swap', function () {
           applyTheme(getTheme());
+          applyFontSize(getFontSize());
         });
       })();
     </script>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -78,6 +78,9 @@ const heroImage = story.content.image?.filename;
         </div>
     </div>
     <div class="px-8 py-12 md:px-12 mx-auto lg:pb-24 max-w-7xl lg:px-32 lg:pt-32">
+      <a href="/" class="inline-flex items-center gap-1 text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-black dark:hover:text-white transition-colors mb-6">
+        ← Alle Beiträge
+      </a>
       <div class="lg:text-center">
         {heroImage && (
           <Image
@@ -110,6 +113,11 @@ const heroImage = story.content.image?.filename;
             </div>
         </div>
         <RelatedPosts posts={relatedPosts} />
+        <div class="max-w-2xl mx-auto mt-12">
+          <a href="/" class="inline-flex items-center gap-1 text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-black dark:hover:text-white transition-colors">
+            ← Alle Beiträge
+          </a>
+        </div>
         <div class="justify-center pt-4 w-full hidden max-lg:flex">
                 <ThemeToggle />
         </div>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -5,6 +5,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { SITE_URL } from "../../consts";
 import {Image} from 'astro:assets';
 import ThemeToggle from "../../components/ThemeToggle.astro";
+import FontSizeToggle from "../../components/FontSizeToggle.astro";
 import { getReadingTime, getExcerpt } from '../../utils/readingTime';
 import { getRelatedPosts } from '../../utils/relatedPosts';
 import { getAllStories, contentVersion } from '../../utils/storyblok';
@@ -73,7 +74,8 @@ const heroImage = story.content.image?.filename;
   publishedDate={story.content.pubDate}
 >
     <div class="relative w-full invisible lg:visible">
-        <div class="absolute right-5 top-5 lg:right-10 lg:top-10">
+        <div class="absolute right-5 top-5 lg:right-10 lg:top-10 flex items-center gap-3">
+            <FontSizeToggle />
             <ThemeToggle />
         </div>
     </div>
@@ -118,7 +120,8 @@ const heroImage = story.content.image?.filename;
             ← Alle Beiträge
           </a>
         </div>
-        <div class="justify-center pt-4 w-full hidden max-lg:flex">
+        <div class="justify-center pt-4 w-full hidden max-lg:flex gap-4">
+                <FontSizeToggle />
                 <ThemeToggle />
         </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,8 +5,9 @@
   font-size: 120%;
 }
 
-html[data-font-size="large"] { font-size: 140%; }
-html[data-font-size="xl"]    { font-size: 165%; }
+/* Scale only prose content text, not rem-based layout dimensions */
+html[data-font-size="large"] .prose-styles { font-size: 1rem; }
+html[data-font-size="xl"]    .prose-styles { font-size: 1.125rem; }
 
 .prose-styles {
   @apply text-sm prose text-neutral-600 prose-a:font-normal prose-a:text-blue-400 hover:prose-a:text-black prose-h1:text-black prose-img:rounded prose-h2:text-black prose-h2:font-semibold prose-p:text-sm prose-pre:font-mono max-w-none prose-pre:rounded-none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,9 @@
   font-size: 120%;
 }
 
+html[data-font-size="large"] { font-size: 140%; }
+html[data-font-size="xl"]    { font-size: 165%; }
+
 .prose-styles {
   @apply text-sm prose text-neutral-600 prose-a:font-normal prose-a:text-blue-400 hover:prose-a:text-black prose-h1:text-black prose-img:rounded prose-h2:text-black prose-h2:font-semibold prose-p:text-sm prose-pre:font-mono max-w-none prose-pre:rounded-none;
 


### PR DESCRIPTION
Adds a 3-step font size cycle (normal → large → xl) next to the existing
dark mode toggle. The chosen size persists via localStorage and is applied
before first render to avoid layout flash.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tp58WkKRXFUtusFdqkQ1QA